### PR TITLE
add GHA to restart streamlit

### DIFF
--- a/.github/workflows/deploy-to-server.yml
+++ b/.github/workflows/deploy-to-server.yml
@@ -15,3 +15,11 @@ jobs:
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
           script: cd /home/forge/streamlit && git pull origin main
+      - name: restarting streamlit and clearing cache
+        uses: appleboy/ssh-action@v0.1.8
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.KEY }}
+          port: ${{ secrets.PORT }}
+          script: sudo supervisorctl restart streamlit && streamlit cache clear


### PR DESCRIPTION
This adds a Github Action step to restart streamlit and clear its cache upon a successful deployment.

Hopefully this gets us around the issue where the config etc. doesn't always get synced up properly