### PR TITLE
Refactor: Cache MFL league data API call in global_vars.py

### DIFF
--- a/global_vars.py
+++ b/global_vars.py
@@ -35,13 +35,18 @@ else:
     league_yr = cur_yr-1
 
 #League Data
-league_url = 'https://www49.myfantasyleague.com/'+str(league_yr)+'/export?TYPE=league&L=59643&APIKEY=&JSON=1'
-r = requests.get(url = league_url)
-league = r.json()["league"]
+@st.cache_data(ttl=dt.timedelta(days=1))
+def get_league_mfl_data():
+    league_url = f'https://www49.myfantasyleague.com/{league_yr}/export?TYPE=league&L=59643&APIKEY=&JSON=1'
+    r = requests.get(url=league_url)
+    r.raise_for_status()  # Raise an exception for bad status codes
+    return r.json()["league"]
+
+league = get_league_mfl_data()
 # roster_size = int(league["rosterSize"])
-roster_size = 20
+roster_size = 20  # This seems to be a hardcoded override
 salary_cap = float(league["salaryCapAmount"])
-contract_cap = 42
+contract_cap = 42 # This is hardcoded
 max_contract_yrs = 5
 
 #Contract Years Lookup


### PR DESCRIPTION
The API call to fetch league data from MFL in `global_vars.py` was previously uncached and executed on every module import.

This change wraps the API call in a new function `get_league_mfl_data()` and decorates it with `@st.cache_data(ttl=dt.timedelta(days=1))`. This ensures the API call is made only once per day (or as per TTL), significantly reducing redundant API calls and improving the performance of Streamlit pages that import `global_vars.py`.

My other investigations into player data fetching (`get_players`, `get_players_wr`) and `calculate_updated_value` usage did not result in further code changes, as no immediate, actionable optimizations were identified in active code paths beyond this primary one.