### PR TITLE
Make LAST_LEAGUE_YEAR dynamic in GHA workflow

### DIFF
--- a/.github/workflows/run_mfl_players_workflow.yml
+++ b/.github/workflows/run_mfl_players_workflow.yml
@@ -7,8 +7,12 @@ env:
   DESTINATION__BIGQUERY__CREDENTIALS__PROJECT_ID: mfl-374514
   DESTINATION__BIGQUERY__CREDENTIALS__CLIENT_EMAIL: mfl-orchestrator@mfl-374514.iam.gserviceaccount.com
   DESTINATION__BIGQUERY__LOCATION: US
-  API_SECRET_KEY: ${{ secrets.API_SECRET_KEY }}
   DESTINATION__BIGQUERY__CREDENTIALS__PRIVATE_KEY: ${{ secrets.DESTINATION__BIGQUERY__CREDENTIALS__PRIVATE_KEY }}
+  API_SECRET_KEY: ${{ secrets.API_SECRET_KEY }} # Keeping this for now
+  HOST: 'www49.myfantasyleague.com'
+  LEAGUE_YEAR: '2025'
+  LEAGUE_ID: '59643'
+  MFL_API_KEY: ${{ secrets.API_SECRET_KEY }}
 
 jobs:
   run_pipeline:
@@ -36,6 +40,9 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v2'
       - name: 'Use gcloud CLI'
         run: 'gcloud info'
+      - name: Calculate LAST_LEAGUE_YEAR
+        run: |
+          echo "LAST_LEAGUE_YEAR=$(($LEAGUE_YEAR - 1))" >> $GITHUB_ENV
       # - name: Run players script
       #   run: python 'dlt/players.py'
       - name: Run draft picks script

--- a/dlt/assets.py
+++ b/dlt/assets.py
@@ -1,18 +1,6 @@
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
-
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
-
 
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
@@ -33,7 +21,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
 
     # make an api call here
-    url = f"https://{config.host}/{config.league_year}/export?TYPE=assets&L={config.league_id}&APIKEY={config.mfl_api_key}&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LEAGUE_YEAR')}/export?TYPE=assets&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()

--- a/dlt/draft_picks.py
+++ b/dlt/draft_picks.py
@@ -1,18 +1,7 @@
 
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
-
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
 
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
@@ -31,7 +20,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
     
     # make an api call here
-    url = f"https://{config.host}/{config.league_year}/export?TYPE=futureDraftPicks&L={config.league_id}&APIKEY={config.mfl_api_key}&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LEAGUE_YEAR')}/export?TYPE=futureDraftPicks&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()

--- a/dlt/last_yr_players.py
+++ b/dlt/last_yr_players.py
@@ -1,17 +1,6 @@
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
-
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
 
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
@@ -32,7 +21,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
 
     # make an api call here
-    url = f"https://{config.host}/{config.last_league_year}/export?TYPE=players&L={config.league_id}&APIKEY={config.mfl_api_key}&DETAILS=&SINCE=&PLAYERS=&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LAST_LEAGUE_YEAR')}/export?TYPE=players&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&DETAILS=&SINCE=&PLAYERS=&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()

--- a/dlt/last_yr_rosters.py
+++ b/dlt/last_yr_rosters.py
@@ -1,17 +1,6 @@
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
-
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
 
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
@@ -32,7 +21,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
 
     # make an api call here
-    url = f"https://{config.host}/{config.last_league_year}/export?TYPE=rosters&L={config.league_id}&APIKEY={config.mfl_api_key}&FRANCHISE=&W=&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LAST_LEAGUE_YEAR')}/export?TYPE=rosters&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&FRANCHISE=&W=&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()

--- a/dlt/last_yr_scores.py
+++ b/dlt/last_yr_scores.py
@@ -1,17 +1,6 @@
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
-
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
 
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
@@ -32,7 +21,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
 
     # make an api call here
-    url = f"https://{config.host}/{config.last_league_year}/export?TYPE=playerScores&L={config.league_id}&APIKEY={config.mfl_api_key}&W=YTD&YEAR=&PLAYERS=&POSITION=&STATUS=&RULES=&COUNT=&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LAST_LEAGUE_YEAR')}/export?TYPE=playerScores&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&W=YTD&YEAR=&PLAYERS=&POSITION=&STATUS=&RULES=&COUNT=&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()

--- a/dlt/league.py
+++ b/dlt/league.py
@@ -1,17 +1,6 @@
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
-
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
 
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
@@ -32,7 +21,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
 
     # make an api call here
-    url = f"https://{config.host}/{config.league_year}/export?TYPE=league&L={config.league_id}&APIKEY={config.mfl_api_key}&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LEAGUE_YEAR')}/export?TYPE=league&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()

--- a/dlt/players.py
+++ b/dlt/players.py
@@ -1,17 +1,7 @@
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
 
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
     return sourcename_resource(api_secret_key)
@@ -31,7 +21,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
 
     # make an api call here
-    url = f"https://{config.host}/{config.league_year}/export?TYPE=players&L={config.league_id}&APIKEY={config.mfl_api_key}&DETAILS=&SINCE=&PLAYERS=&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LEAGUE_YEAR')}/export?TYPE=players&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&DETAILS=&SINCE=&PLAYERS=&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()

--- a/dlt/results.py
+++ b/dlt/results.py
@@ -1,17 +1,6 @@
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
-
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
 
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
@@ -32,7 +21,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
 
     # make an api call here
-    url = f"https://{config.host}/{config.league_year}/export?TYPE=weeklyResults&L={config.league_id}&APIKEY={config.mfl_api_key}&W=YTD&MISSING_AS_BYE=&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LEAGUE_YEAR')}/export?TYPE=weeklyResults&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&W=YTD&MISSING_AS_BYE=&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()

--- a/dlt/rosters.py
+++ b/dlt/rosters.py
@@ -1,17 +1,6 @@
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
-
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
 
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
@@ -32,7 +21,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
 
     # make an api call here
-    url = f"https://{config.host}/{config.league_year}/export?TYPE=rosters&L={config.league_id}&APIKEY={config.mfl_api_key}&FRANCHISE=&W=&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LEAGUE_YEAR')}/export?TYPE=rosters&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&FRANCHISE=&W=&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()

--- a/dlt/schedule.py
+++ b/dlt/schedule.py
@@ -1,17 +1,6 @@
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
-
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
 
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
@@ -32,7 +21,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
 
     # make an api call here
-    url = f"https://{config.host}/{config.league_year}/export?TYPE=schedule&L={config.league_id}&APIKEY={config.mfl_api_key}&W=&F=&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LEAGUE_YEAR')}/export?TYPE=schedule&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&W=&F=&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()

--- a/dlt/scores.py
+++ b/dlt/scores.py
@@ -1,17 +1,6 @@
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
-
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
 
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
@@ -32,7 +21,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
 
     # make an api call here
-    url = f"https://{config.host}/{config.league_year}/export?TYPE=playerScores&L={config.league_id}&APIKEY={config.mfl_api_key}&W=YTD&YEAR=&PLAYERS=&POSITION=&STATUS=&RULES=&COUNT=&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LEAGUE_YEAR')}/export?TYPE=playerScores&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&W=YTD&YEAR=&PLAYERS=&POSITION=&STATUS=&RULES=&COUNT=&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()

--- a/dlt/standings.py
+++ b/dlt/standings.py
@@ -1,17 +1,6 @@
 import os
-import sys
 import dlt
 from dlt.sources.helpers import requests
-
-# Get the directory of the current script
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Get the parent directory (where config.py is)
-parent_dir = os.path.dirname(script_dir)
-# Add parent directory to sys.path
-sys.path.insert(0, parent_dir)
-
-# Now import config
-import config
 
 @dlt.source
 def sourcename_source(api_secret_key=dlt.secrets.value):
@@ -32,7 +21,7 @@ def sourcename_resource(api_secret_key=dlt.secrets.value):
     print(headers)
 
     # make an api call here
-    url = f"https://{config.host}/{config.league_year}/export?TYPE=leagueStandings&L={config.league_id}&APIKEY={config.mfl_api_key}&COLUMN_NAMES=&ALL=&WEB=&JSON=1"
+    url = f"https://{os.environ.get('HOST')}/{os.environ.get('LEAGUE_YEAR')}/export?TYPE=leagueStandings&L={os.environ.get('LEAGUE_ID')}&APIKEY={os.environ.get('MFL_API_KEY')}&COLUMN_NAMES=&ALL=&WEB=&JSON=1"
     response = requests.get(url)
     response.raise_for_status()
     yield response.json()


### PR DESCRIPTION
Previously, LAST_LEAGUE_YEAR was set to a static value in the GitHub Actions workflow. This commit updates the workflow to calculate LAST_LEAGUE_YEAR dynamically by subtracting 1 from the LEAGUE_YEAR environment variable.

This is achieved by adding a new step in the 'run_pipeline' job that performs the calculation and exports LAST_LEAGUE_YEAR to the GitHub environment, making it available for subsequent steps that run dlt scripts.

This makes the workflow more maintainable as LEAGUE_YEAR changes.