### PR TITLE
Fix: Correct GHA execution for dlt scripts

### DIFF
--- a/.github/workflows/run_mfl_players_workflow.yml
+++ b/.github/workflows/run_mfl_players_workflow.yml
@@ -46,13 +46,13 @@ jobs:
       # - name: Run players script
       #   run: python 'dlt/players.py'
       - name: Run draft picks script
-        run: python 'dlt/draft_picks.py'
+        run: python -m dlt.draft_picks
       # - name: Run league script
       #   run: python 'dlt/league.py'
       # - name: Run rosters script
       #   run: python 'dlt/rosters.py'
       - name: Run assets script
-        run: python 'dlt/assets.py'
+        run: python -m dlt.assets
       # - name: Run schedule script
       #   run: python 'dlt/schedule.py'
       # - name: Run scores script


### PR DESCRIPTION
The GHA workflow was previously invoking python scripts within the 'dlt' directory directly (e.g., `python dlt/draft_picks.py`). This caused `ImportError: attempted relative import with no known parent package` because Python did not recognize 'dlt' as a package in that execution context, breaking relative imports like `from . import common`.

This commit changes the execution method in
`.github/workflows/run_mfl_players_workflow.yml` to use `python -m dlt.script_name`. This ensures that Python treats the 'dlt' directory as a package, allowing relative imports to function correctly.

The affected scripts are:
- dlt/draft_picks.py
- dlt/assets.py