### PR TITLE
Fix: Add __init__.py to dlt directory

### DIFF
--- a/.github/workflows/run_mfl_players_workflow.yml
+++ b/.github/workflows/run_mfl_players_workflow.yml
@@ -46,13 +46,13 @@ jobs:
       # - name: Run players script
       #   run: python 'dlt/players.py'
       - name: Run draft picks script
-        run: python 'dlt/draft_picks.py'
+        run: python -m dlt.draft_picks
       # - name: Run league script
       #   run: python 'dlt/league.py'
       # - name: Run rosters script
       #   run: python 'dlt/rosters.py'
       - name: Run assets script
-        run: python 'dlt/assets.py'
+        run: python -m dlt.assets
       # - name: Run schedule script
       #   run: python 'dlt/schedule.py'
       # - name: Run scores script


### PR DESCRIPTION
To resolve the "No module named dlt.draft_picks" error in the GHA workflow when using `python -m dlt.script_name`, this commit adds an empty `__init__.py` file to the `dlt` directory.

This file signals to Python that the `dlt` directory should be treated as a package, enabling module resolution for scripts executed with `python -m`. The previous fix changed the execution from `python dlt/script.py` to `python -m dlt.script_name`, which necessitated `dlt` being a recognizable package.