### PR TITLE
I've added `.dlt/secrets.toml` to your `.gitignore` file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 9_🏅_Points_Race pai.py
 .streamlit/secrets.toml
 .dlt
+.dlt/secrets.toml
 


### PR DESCRIPTION
This will prevent you from accidentally committing sensitive API keys. It's a good practice to do this when you're using local secrets files for your dlt pipelines.