### PR TITLE
Refactor: Remove unused `last_league_year` imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 9_🏅_Points_Race pai.py
 .streamlit/secrets.toml
 .dlt
+.dlt/secrets.toml
 

--- a/dlt_scripts/assets.py
+++ b/dlt_scripts/assets.py
@@ -1,7 +1,7 @@
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
-from global_vars import host, league_id, league_year, last_league_year
+from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")

--- a/dlt_scripts/draft_picks.py
+++ b/dlt_scripts/draft_picks.py
@@ -1,7 +1,7 @@
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
-from global_vars import host, league_id, league_year, last_league_year
+from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")

--- a/dlt_scripts/league.py
+++ b/dlt_scripts/league.py
@@ -1,7 +1,7 @@
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
-from global_vars import host, league_id, league_year, last_league_year
+from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")

--- a/dlt_scripts/players.py
+++ b/dlt_scripts/players.py
@@ -1,7 +1,7 @@
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
-from global_vars import host, league_id, league_year, last_league_year
+from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")

--- a/dlt_scripts/results.py
+++ b/dlt_scripts/results.py
@@ -1,7 +1,7 @@
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
-from global_vars import host, league_id, league_year, last_league_year
+from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")

--- a/dlt_scripts/rosters.py
+++ b/dlt_scripts/rosters.py
@@ -1,7 +1,7 @@
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
-from global_vars import host, league_id, league_year, last_league_year
+from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")

--- a/dlt_scripts/schedule.py
+++ b/dlt_scripts/schedule.py
@@ -1,7 +1,7 @@
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
-from global_vars import host, league_id, league_year, last_league_year
+from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")

--- a/dlt_scripts/scores.py
+++ b/dlt_scripts/scores.py
@@ -1,7 +1,7 @@
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
-from global_vars import host, league_id, league_year, last_league_year
+from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")

--- a/dlt_scripts/standings.py
+++ b/dlt_scripts/standings.py
@@ -1,7 +1,7 @@
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
-from global_vars import host, league_id, league_year, last_league_year
+from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")


### PR DESCRIPTION
I removed the unused import of `last_league_year` from `global_vars` in the following files:
- dlt_scripts/assets.py
- dlt_scripts/draft_picks.py
- dlt_scripts/league.py
- dlt_scripts/players.py
- dlt_scripts/results.py
- dlt_scripts/rosters.py
- dlt_scripts/schedule.py
- dlt_scripts/scores.py
- dlt_scripts/standings.py

The `last_league_year` variable in `global_vars.py` is still in use by other scripts (`last_yr_players.py`, `last_yr_rosters.py`, `last_yr_scores.py`) and has not been removed.