### PR TITLE
Fix(assets): Correct sourcename_source to yield resource

### DIFF
--- a/dlt_scripts/assets.py
+++ b/dlt_scripts/assets.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def assets_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=assets&L={league_id}&APIKEY={mfl_api_key}&JSON=1"
@@ -18,8 +16,8 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(assets_resource):
-    yield assets_resource
+def assets_source(resource_func): # Changed argument name to be generic like others
+    yield resource_func
 
 
 if __name__ == "__main__":
@@ -28,6 +26,6 @@ if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_assets',
         dataset_name='assets',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=assets_resource, # Use the renamed resource
+        source_func=assets_source # Use the renamed source
     )

--- a/dlt_scripts/draft_picks.py
+++ b/dlt_scripts/draft_picks.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def draft_picks_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=futureDraftPicks&L={league_id}&APIKEY={mfl_api_key}&JSON=1"
@@ -18,14 +16,14 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(sourcename_resource_func=dlt.secrets.value):
-    yield sourcename_resource_func
+def draft_picks_source(resource_func):
+    yield resource_func
 
 
 if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_draft_picks',
         dataset_name='draft_picks',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=draft_picks_resource, # Use the renamed resource
+        source_func=draft_picks_source # Use the renamed source
     )

--- a/dlt_scripts/last_yr_players.py
+++ b/dlt_scripts/last_yr_players.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year, last_league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def last_yr_players_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{last_league_year}/export?TYPE=players&L={league_id}&APIKEY={mfl_api_key}&DETAILS=&SINCE=&PLAYERS=&JSON=1"
@@ -18,14 +16,14 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(sourcename_resource_func=dlt.secrets.value):
-    yield sourcename_resource_func
+def last_yr_players_source(resource_func):
+    yield resource_func
 
 
 if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_last_yr_players',
         dataset_name='last_yr_players',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=last_yr_players_resource,
+        source_func=last_yr_players_source
     )

--- a/dlt_scripts/last_yr_rosters.py
+++ b/dlt_scripts/last_yr_rosters.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year, last_league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def last_yr_rosters_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{last_league_year}/export?TYPE=rosters&L={league_id}&APIKEY={mfl_api_key}&FRANCHISE=&W=&JSON=1"
@@ -18,14 +16,14 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(sourcename_resource_func=dlt.secrets.value):
-    yield sourcename_resource_func
+def last_yr_rosters_source(resource_func):
+    yield resource_func
 
 
 if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_last_yr_rosters',
         dataset_name='last_yr_rosters',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=last_yr_rosters_resource,
+        source_func=last_yr_rosters_source
     )

--- a/dlt_scripts/last_yr_scores.py
+++ b/dlt_scripts/last_yr_scores.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year, last_league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def last_yr_scores_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{last_league_year}/export?TYPE=playerScores&L={league_id}&APIKEY={mfl_api_key}&W=YTD&YEAR=&PLAYERS=&POSITION=&STATUS=&RULES=&COUNT=&JSON=1"
@@ -18,14 +16,14 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(sourcename_resource_func=dlt.secrets.value):
-    yield sourcename_resource_func
+def last_yr_scores_source(resource_func):
+    yield resource_func
 
 
 if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_last_yr_scores',
         dataset_name='last_yr_scores',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=last_yr_scores_resource,
+        source_func=last_yr_scores_source
     )

--- a/dlt_scripts/league.py
+++ b/dlt_scripts/league.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def league_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=league&L={league_id}&APIKEY={mfl_api_key}&JSON=1"
@@ -18,14 +16,14 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(sourcename_resource_func=dlt.secrets.value):
-    yield sourcename_resource_func
+def league_source(resource_func):
+    yield resource_func
 
 
 if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_league',
         dataset_name='league',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=league_resource,
+        source_func=league_source
     )

--- a/dlt_scripts/players.py
+++ b/dlt_scripts/players.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def players_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=players&L={league_id}&APIKEY={mfl_api_key}&DETAILS=&SINCE=&PLAYERS=&JSON=1"
@@ -18,14 +16,14 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(sourcename_resource_func=dlt.secrets.value):
-    yield sourcename_resource_func
+def players_source(resource_func):
+    yield resource_func
 
 
 if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_players',
         dataset_name='players',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=players_resource,
+        source_func=players_source
     )

--- a/dlt_scripts/results.py
+++ b/dlt_scripts/results.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def results_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=weeklyResults&L={league_id}&APIKEY={mfl_api_key}&W=YTD&MISSING_AS_BYE=&JSON=1"
@@ -18,14 +16,14 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(sourcename_resource_func=dlt.secrets.value):
-    yield sourcename_resource_func
+def results_source(resource_func):
+    yield resource_func
 
 
 if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_results',
         dataset_name='results',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=results_resource,
+        source_func=results_source
     )

--- a/dlt_scripts/rosters.py
+++ b/dlt_scripts/rosters.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def rosters_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=rosters&L={league_id}&APIKEY={mfl_api_key}&FRANCHISE=&W=&JSON=1"
@@ -18,14 +16,14 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(sourcename_resource_func=dlt.secrets.value):
-    yield sourcename_resource_func
+def rosters_source(resource_func):
+    yield resource_func
 
 
 if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_rosters',
         dataset_name='rosters',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=rosters_resource,
+        source_func=rosters_source
     )

--- a/dlt_scripts/schedule.py
+++ b/dlt_scripts/schedule.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def schedule_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=schedule&L={league_id}&APIKEY={mfl_api_key}&W=&F=&JSON=1"
@@ -18,14 +16,14 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(sourcename_resource_func=dlt.secrets.value):
-    yield sourcename_resource_func
+def schedule_source(resource_func):
+    yield resource_func
 
 
 if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_schedule',
         dataset_name='schedule',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=schedule_resource,
+        source_func=schedule_source
     )

--- a/dlt_scripts/scores.py
+++ b/dlt_scripts/scores.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def scores_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=playerScores&L={league_id}&APIKEY={mfl_api_key}&W=YTD&YEAR=&PLAYERS=&POSITION=&STATUS=&RULES=&COUNT=&JSON=1"
@@ -18,14 +16,14 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(sourcename_resource_func=dlt.secrets.value):
-    yield sourcename_resource_func
+def scores_source(resource_func):
+    yield resource_func
 
 
 if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_scores',
         dataset_name='scores',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=scores_resource,
+        source_func=scores_source
     )

--- a/dlt_scripts/standings.py
+++ b/dlt_scripts/standings.py
@@ -5,11 +5,9 @@ from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
-def sourcename_resource(mfl_api_key=dlt.secrets.value):
-    headers = _create_auth_headers(mfl_api_key)
-
-    # check if authentication headers look fine
-    print(headers)
+def standings_resource(mfl_api_key=dlt.secrets.value):
+    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
+    # print(headers)
 
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=leagueStandings&L={league_id}&APIKEY={mfl_api_key}&COLUMN_NAMES=&ALL=&WEB=&JSON=1"
@@ -18,14 +16,14 @@ def sourcename_resource(mfl_api_key=dlt.secrets.value):
     yield response.json()
 
 @dlt.source
-def sourcename_source(sourcename_resource_func=dlt.secrets.value):
-    yield sourcename_resource_func
+def standings_source(resource_func):
+    yield resource_func
 
 
 if __name__ == "__main__":
     create_dlt_pipeline(
         pipeline_name='mfl_standings',
         dataset_name='standings',
-        resource_func=sourcename_resource,
-        source_func=sourcename_source
+        resource_func=standings_resource,
+        source_func=standings_source
     )


### PR DESCRIPTION
The original sourcename_source function in dlt_scripts/assets.py was incorrectly trying to access the resource function via dlt.secrets.value. This change corrects it to directly yield the sourcename_resource, which should resolve the issue of no data being written to BigQuery.

Verification of data being written to BigQuery will need to be performed in an environment where DLT secrets (specifically the MFL_API_KEY) are properly configured.