### PR TITLE
Feat(dlt): Add force_create_mode for robust table creation in GHA

### DIFF
--- a/dlt_scripts/assets.py
+++ b/dlt_scripts/assets.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -63,9 +64,11 @@ def assets_source(resource_func): # Changed argument name to be generic like oth
 
 
 if __name__ == "__main__":
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
     create_dlt_pipeline(
         pipeline_name='mfl_assets',
         dataset_name='assets',
-        resource_func=assets_resource, # Use the renamed resource
-        source_func=assets_source # Use the renamed source
+        resource_func=assets_resource,
+        source_func=assets_source,
+        force_create_mode=force_create
     )

--- a/dlt_scripts/common.py
+++ b/dlt_scripts/common.py
@@ -6,15 +6,38 @@ def _create_auth_headers(api_secret_key):
     headers = {"Authorization": f"Bearer {api_secret_key}"}
     return headers
 
-def create_dlt_pipeline(pipeline_name, dataset_name, resource_func, source_func):
-    """Creates and runs a DLT pipeline."""
-    pipeline = dlt.pipeline(
+def create_dlt_pipeline(pipeline_name, dataset_name, resource_func, source_func, write_disposition=None, force_create_mode=False):
+    """Creates and runs a DLT pipeline.
+    If force_create_mode is True, uses 'replace' disposition and 'drop_sources' refresh mode.
+    Otherwise, defaults to 'append' if write_disposition is None.
+    """
+
+    pipeline_obj = dlt.pipeline(
         pipeline_name=pipeline_name,
         destination='bigquery',
         dataset_name=dataset_name
     )
-    # Apply the resource_func to the source_func before passing to pipeline.run
-    load_info = pipeline.run(source_func(resource_func))
-    print(load_info)
 
-    return load_info
+    run_options = {}
+    effective_write_disposition = write_disposition
+
+    if force_create_mode:
+        print(f"Pipeline '{pipeline_name}': force_create_mode is True. Using 'replace' disposition and 'drop_sources' refresh mode.")
+        effective_write_disposition = "replace"
+        run_options["refresh"] = "drop_sources"
+    elif effective_write_disposition is None:
+        effective_write_disposition = "append"
+
+    run_options["write_disposition"] = effective_write_disposition
+
+    print(f"Running pipeline '{pipeline_name}' with options: {run_options}")
+
+    try:
+        # Apply the resource_func to the source_func before passing to pipeline.run
+        load_info = pipeline_obj.run(source_func(resource_func), **run_options)
+        print(f"Pipeline '{pipeline_name}' completed successfully with options: {run_options}")
+        print(load_info)
+        return load_info
+    except Exception as e:
+        print(f"An error occurred during pipeline '{pipeline_name}' run with options {run_options}: {e}")
+        raise

--- a/dlt_scripts/draft_picks.py
+++ b/dlt_scripts/draft_picks.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -21,9 +22,11 @@ def draft_picks_source(resource_func):
 
 
 if __name__ == "__main__":
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
     create_dlt_pipeline(
         pipeline_name='mfl_draft_picks',
         dataset_name='draft_picks',
-        resource_func=draft_picks_resource, # Use the renamed resource
-        source_func=draft_picks_source # Use the renamed source
+        resource_func=draft_picks_resource,
+        source_func=draft_picks_source,
+        force_create_mode=force_create
     )

--- a/dlt_scripts/last_yr_players.py
+++ b/dlt_scripts/last_yr_players.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -21,9 +22,11 @@ def last_yr_players_source(resource_func):
 
 
 if __name__ == "__main__":
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
     create_dlt_pipeline(
         pipeline_name='mfl_last_yr_players',
         dataset_name='last_yr_players',
         resource_func=last_yr_players_resource,
-        source_func=last_yr_players_source
+        source_func=last_yr_players_source,
+        force_create_mode=force_create
     )

--- a/dlt_scripts/last_yr_rosters.py
+++ b/dlt_scripts/last_yr_rosters.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -21,9 +22,11 @@ def last_yr_rosters_source(resource_func):
 
 
 if __name__ == "__main__":
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
     create_dlt_pipeline(
         pipeline_name='mfl_last_yr_rosters',
         dataset_name='last_yr_rosters',
         resource_func=last_yr_rosters_resource,
-        source_func=last_yr_rosters_source
+        source_func=last_yr_rosters_source,
+        force_create_mode=force_create
     )

--- a/dlt_scripts/last_yr_scores.py
+++ b/dlt_scripts/last_yr_scores.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -21,9 +22,11 @@ def last_yr_scores_source(resource_func):
 
 
 if __name__ == "__main__":
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
     create_dlt_pipeline(
         pipeline_name='mfl_last_yr_scores',
         dataset_name='last_yr_scores',
         resource_func=last_yr_scores_resource,
-        source_func=last_yr_scores_source
+        source_func=last_yr_scores_source,
+        force_create_mode=force_create
     )

--- a/dlt_scripts/league.py
+++ b/dlt_scripts/league.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -21,9 +22,11 @@ def league_source(resource_func):
 
 
 if __name__ == "__main__":
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
     create_dlt_pipeline(
         pipeline_name='mfl_league',
         dataset_name='league',
         resource_func=league_resource,
-        source_func=league_source
+        source_func=league_source,
+        force_create_mode=force_create
     )

--- a/dlt_scripts/players.py
+++ b/dlt_scripts/players.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -21,9 +22,11 @@ def players_source(resource_func):
 
 
 if __name__ == "__main__":
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
     create_dlt_pipeline(
         pipeline_name='mfl_players',
         dataset_name='players',
         resource_func=players_resource,
-        source_func=players_source
+        source_func=players_source,
+        force_create_mode=force_create
     )

--- a/dlt_scripts/results.py
+++ b/dlt_scripts/results.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -21,9 +22,11 @@ def results_source(resource_func):
 
 
 if __name__ == "__main__":
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
     create_dlt_pipeline(
         pipeline_name='mfl_results',
         dataset_name='results',
         resource_func=results_resource,
-        source_func=results_source
+        source_func=results_source,
+        force_create_mode=force_create
     )

--- a/dlt_scripts/rosters.py
+++ b/dlt_scripts/rosters.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -21,9 +22,12 @@ def rosters_source(resource_func):
 
 
 if __name__ == "__main__":
-    create_dlt_pipeline(
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
+    load_info = create_dlt_pipeline(
         pipeline_name='mfl_rosters',
         dataset_name='rosters',
         resource_func=rosters_resource,
-        source_func=rosters_source
+        source_func=rosters_source,
+        force_create_mode=force_create
     )
+    print(load_info)

--- a/dlt_scripts/schedule.py
+++ b/dlt_scripts/schedule.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -21,9 +22,11 @@ def schedule_source(resource_func):
 
 
 if __name__ == "__main__":
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
     create_dlt_pipeline(
         pipeline_name='mfl_schedule',
         dataset_name='schedule',
         resource_func=schedule_resource,
-        source_func=schedule_source
+        source_func=schedule_source,
+        force_create_mode=force_create
     )

--- a/dlt_scripts/scores.py
+++ b/dlt_scripts/scores.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -21,9 +22,11 @@ def scores_source(resource_func):
 
 
 if __name__ == "__main__":
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
     create_dlt_pipeline(
         pipeline_name='mfl_scores',
         dataset_name='scores',
         resource_func=scores_resource,
-        source_func=scores_source
+        source_func=scores_source,
+        force_create_mode=force_create
     )

--- a/dlt_scripts/standings.py
+++ b/dlt_scripts/standings.py
@@ -1,3 +1,4 @@
+import os
 import dlt
 from dlt.sources.helpers import requests
 from .common import _create_auth_headers, create_dlt_pipeline
@@ -21,9 +22,11 @@ def standings_source(resource_func):
 
 
 if __name__ == "__main__":
+    force_create = os.getenv("FORCE_DLT_CREATE_MODE", "false").lower() == "true"
     create_dlt_pipeline(
         pipeline_name='mfl_standings',
         dataset_name='standings',
         resource_func=standings_resource,
-        source_func=standings_source
+        source_func=standings_source,
+        force_create_mode=force_create
     )


### PR DESCRIPTION
- Modifies `common.py`'s `create_dlt_pipeline` function to accept a `force_create_mode` boolean parameter.
- If `force_create_mode` is True, the pipeline is run with `write_disposition="replace"` and `refresh="drop_sources"`. This ensures all tables for the source are dropped and recreated, robustly handling initial creation or recreation after deletion, including complex child tables.
- If `force_create_mode` is False (default), `create_dlt_pipeline` defaults to `write_disposition="append"` (if no other disposition is specified), suitable for incremental loads to existing tables.
- All individual dlt scripts in `dlt_scripts/` have been updated to read a `FORCE_DLT_CREATE_MODE` environment variable. This variable's value determines the `force_create_mode` flag passed to `create_dlt_pipeline`, allowing GHA workflows to control this behavior.

This addresses issues where `append` or `replace` alone might fail in GHA due to missing (child) tables during schema reconciliation or storage initialization by dlt.