### PR TITLE
refactor: Remove unused create_auth_headers function

### DIFF
--- a/dlt_scripts/assets.py
+++ b/dlt_scripts/assets.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
 def assets_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     print(f"[assets_resource] Requesting URL: https://{host}/{league_year}/export?TYPE=assets&L={league_id}&APIKEY=MASKED_FOR_LOG&JSON=1")
     url = f"https://{host}/{league_year}/export?TYPE=assets&L={league_id}&APIKEY={mfl_api_key}&JSON=1"

--- a/dlt_scripts/cap_penalties.py
+++ b/dlt_scripts/cap_penalties.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
 def league_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=salaryAdjustments&L={league_id}&APIKEY={mfl_api_key}&JSON=1"
     response = requests.get(url)

--- a/dlt_scripts/common.py
+++ b/dlt_scripts/common.py
@@ -1,11 +1,6 @@
 import dlt
 from dlt.sources.helpers import requests
 
-def _create_auth_headers(api_secret_key):
-    """Constructs Bearer type authorization header which is the most common authorization method"""
-    headers = {"Authorization": f"Bearer {api_secret_key}"}
-    return headers
-
 def create_dlt_pipeline(pipeline_name, dataset_name, resource_func, source_func, write_disposition=None, force_create_mode=False):
     """Creates and runs a DLT pipeline.
     """

--- a/dlt_scripts/draft_picks.py
+++ b/dlt_scripts/draft_picks.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
 def draft_picks_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=futureDraftPicks&L={league_id}&APIKEY={mfl_api_key}&JSON=1"
     response = requests.get(url)

--- a/dlt_scripts/last_yr_players.py
+++ b/dlt_scripts/last_yr_players.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year, last_league_year
 
 
 @dlt.resource(write_disposition="replace")
 def last_yr_players_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{last_league_year}/export?TYPE=players&L={league_id}&APIKEY={mfl_api_key}&DETAILS=&SINCE=&PLAYERS=&JSON=1"
     response = requests.get(url)

--- a/dlt_scripts/last_yr_rosters.py
+++ b/dlt_scripts/last_yr_rosters.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year, last_league_year
 
 
 @dlt.resource(write_disposition="replace")
 def last_yr_rosters_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{last_league_year}/export?TYPE=rosters&L={league_id}&APIKEY={mfl_api_key}&FRANCHISE=&W=&JSON=1"
     response = requests.get(url)

--- a/dlt_scripts/last_yr_scores.py
+++ b/dlt_scripts/last_yr_scores.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year, last_league_year
 
 
 @dlt.resource(write_disposition="replace")
 def last_yr_scores_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{last_league_year}/export?TYPE=playerScores&L={league_id}&APIKEY={mfl_api_key}&W=YTD&YEAR=&PLAYERS=&POSITION=&STATUS=&RULES=&COUNT=&JSON=1"
     response = requests.get(url)

--- a/dlt_scripts/league.py
+++ b/dlt_scripts/league.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
 def league_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=league&L={league_id}&APIKEY={mfl_api_key}&JSON=1"
     response = requests.get(url)

--- a/dlt_scripts/players.py
+++ b/dlt_scripts/players.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
 def players_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=players&L={league_id}&APIKEY={mfl_api_key}&DETAILS=&SINCE=&PLAYERS=&JSON=1"
     response = requests.get(url)

--- a/dlt_scripts/results.py
+++ b/dlt_scripts/results.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
 def results_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=weeklyResults&L={league_id}&APIKEY={mfl_api_key}&W=YTD&MISSING_AS_BYE=&JSON=1"
     response = requests.get(url)

--- a/dlt_scripts/rosters.py
+++ b/dlt_scripts/rosters.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
 def rosters_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=rosters&L={league_id}&APIKEY={mfl_api_key}&FRANCHISE=&W=&JSON=1"
     response = requests.get(url)

--- a/dlt_scripts/schedule.py
+++ b/dlt_scripts/schedule.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
 def schedule_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=schedule&L={league_id}&APIKEY={mfl_api_key}&W=&F=&JSON=1"
     response = requests.get(url)

--- a/dlt_scripts/scores.py
+++ b/dlt_scripts/scores.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
 def scores_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=playerScores&L={league_id}&APIKEY={mfl_api_key}&W=YTD&YEAR=&PLAYERS=&POSITION=&STATUS=&RULES=&COUNT=&JSON=1"
     response = requests.get(url)

--- a/dlt_scripts/standings.py
+++ b/dlt_scripts/standings.py
@@ -1,15 +1,12 @@
 import os
 import dlt
 from dlt.sources.helpers import requests
-from .common import _create_auth_headers, create_dlt_pipeline
+from .common import create_dlt_pipeline
 from global_vars import host, league_id, league_year
 
 
 @dlt.resource(write_disposition="replace")
 def standings_resource(mfl_api_key=dlt.secrets.value):
-    # headers = _create_auth_headers(mfl_api_key) # Not used by MFL API if key is in URL
-    # print(headers)
-
     # make an api call here
     url = f"https://{host}/{league_year}/export?TYPE=leagueStandings&L={league_id}&APIKEY={mfl_api_key}&COLUMN_NAMES=&ALL=&WEB=&JSON=1"
     response = requests.get(url)


### PR DESCRIPTION
This commit removes the unused `_create_auth_headers` function from `dlt_scripts/common.py` and all references to it in other scripts. The function was not being used and was commented out in all the files that imported it.